### PR TITLE
fixes vercel client side routing and adds meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,28 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/png" href="/icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>NEAR Protocol Rewards Dashboard</title>
+    <meta name="description" content="Discover a developer-focused rewards dashboard for the NEAR Protocol ecosystem. Track contributions, earn merit-based rewards, and manage project impact with automated metrics and sustainable funding." />
+
+    <!-- Google / Search Engine Tags -->
+    <meta itemprop="name" content="NEAR Protocol Rewards Dashboard" />
+    <meta itemprop="description" content="Discover a developer-focused rewards dashboard for the NEAR Protocol ecosystem. Track contributions, earn merit-based rewards, and manage project impact with automated metrics and sustainable funding." />
+    <meta itemprop="image" content="/og-image.png" />
+
+    <!-- Facebook Meta Tags -->
+    <meta property="og:url" content="https://protocol-rewards-dashboard.vercel.app" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="NEAR Protocol Rewards Dashboard" />
+    <meta property="og:description" content="Discover a developer-focused rewards dashboard for the NEAR Protocol ecosystem. Track contributions, earn merit-based rewards, and manage project impact with automated metrics and sustainable funding." />
+    <meta property="og:image" content="/og-image.png" />
+
+    <!-- Twitter Meta Tags -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="NEAR Protocol Rewards Dashboard" />
+    <meta name="twitter:description" content="Discover a developer-focused rewards dashboard for the NEAR Protocol ecosystem. Track contributions, earn merit-based rewards, and manage project impact with automated metrics and sustainable funding." />
+    <meta name="twitter:image" content="/og-image.png" />
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/PriorityActions.tsx
+++ b/src/components/PriorityActions.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Target, GitPullRequest, Code, Users, ArrowRight } from 'lucide-react';
 import { Tooltip } from './ui/Tooltip';
 import { useRewards } from '../hooks/useRewards';
+import { Link } from 'react-router-dom';
 
 interface ActionItem {
   id: string;
@@ -79,9 +80,9 @@ export function PriorityActions() {
 
         <div className="space-y-3">
           {actions.map((action) => (
-            <a
+            <Link
               key={action.id}
-              href={action.link}
+              to={action.link}
               className="flex items-center justify-between p-4 bg-black/20 backdrop-blur-sm rounded-lg 
                        hover:bg-white/10 transition-colors group border border-white/5 hover:border-near-purple/20"
             >
@@ -100,7 +101,7 @@ export function PriorityActions() {
                 </Tooltip>
                 <ArrowRight className="w-4 h-4 text-gray-400 group-hover:text-near-purple transition-colors" />
               </div>
-            </a>
+            </Link>
           ))}
         </div>
       </div>

--- a/src/components/RepoSelector.tsx
+++ b/src/components/RepoSelector.tsx
@@ -193,7 +193,9 @@ export function RepoSelector() {
                   Your data is securely handled and only used for calculating rewards. 
                   Learn more in our{' '}
                   <a 
-                    href="/privacy-policy" 
+                    href="https://near.org/privacy"
+                    target="_blank"
+                    rel="noopener noreferrer"
                     className="text-near-purple hover:text-near-purple/80 
                              underline transition-colors"
                   >

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
# Overview 
- fixes vercel client side routing issue, adds vercel.json
- converts `<a />` tags to react router `<Link />`, leads to faster navigation
- adds metadata and icon to index.html

# Context 

I noticed an issue when trying to login with Github or navigating to the site, that Vercel will through 404 error. This is because it's a client side app (Vite), and vercel typically expects SSR apps (Next.js). For example, try navigating to https://protocol-rewards-dashboard.vercel.app/repos/quantum-relay/pulls

This pull request adds a vercel.json that redirects requests through the index.html -- this solves the above and should solve the Github login callback, although I'm not positive, I did not go through the effort to grab github app variables for local environment. If this is still broken, I can investigate.

Also, this pull request updates the metadata tags in index.html, see how it will appear here:

https://www.heymeta.com/results?url=protocol-rewards-dashboard-mu.vercel.app
